### PR TITLE
feat: Preserve window list scroll position on auto-refresh

### DIFF
--- a/manager.js
+++ b/manager.js
@@ -47,6 +47,10 @@ async function loadActiveWindows() {
 function renderActiveWindows() {
   const container = document.getElementById('windowsList');
   
+  // Save current scroll position
+  const scrollTop = container.scrollTop;
+  const scrollLeft = container.scrollLeft;
+  
   if (currentWindows.length === 0) {
     container.innerHTML = `
       <div class="empty-state">
@@ -63,6 +67,10 @@ function renderActiveWindows() {
     const windowCard = createWindowCard(window, index);
     container.appendChild(windowCard);
   });
+  
+  // Restore scroll position after rendering
+  container.scrollTop = scrollTop;
+  container.scrollLeft = scrollLeft;
 }
 
 function createWindowCard(window, index) {


### PR DESCRIPTION
## Summary
- Window list scroll position is now preserved when the manager interface auto-refreshes
- Users can maintain their scroll position while browsing through windows

## Changes
- Modified `renderActiveWindows()` function to save scroll position before rendering
- Restore scroll position after DOM updates complete

## Test plan
- [ ] Open the manager interface with multiple windows
- [ ] Scroll down in the window list
- [ ] Wait for auto-refresh or trigger a refresh by opening/closing tabs
- [ ] Verify that scroll position is maintained after refresh

🤖 Generated with [Claude Code](https://claude.ai/code)